### PR TITLE
React 19 drops forwardRef

### DIFF
--- a/runtime/react-jsx.js
+++ b/runtime/react-jsx.js
@@ -1,16 +1,48 @@
-import { forwardRef } from "react";
+import { forwardRef, version } from "react";
 import { jsx } from "react/jsx-runtime";
 
-export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => {
+export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (
+	viewBox,
+	width,
+	height,
+	symbol
+) => {
 	let node = jsx("use", { href: symbol });
 
-	return forwardRef((props, ref) => {
-		return jsx("svg", { ref, viewBox, width, height, ...props, children: node });
-	});
+	if (version.split(".")[0] < "19") {
+		return forwardRef((props, ref) => {
+			return jsx("svg", {
+				ref,
+				viewBox,
+				width,
+				height,
+				...props,
+				children: node,
+			});
+		});
+	} else {
+		return jsx("svg", { ref, viewBox, width, height, children: node });
+	}
 };
 
-export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => {
-	return forwardRef((props, ref) => {
+export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (
+	viewBox,
+	width,
+	height,
+	xml
+) => {
+	if (version.split(".")[0] < "19") {
+		return forwardRef((props, ref) => {
+			return jsx("svg", {
+				ref,
+				viewBox,
+				width,
+				height,
+				...props,
+				dangerouslySetInnerHTML: { __html: xml },
+			});
+		});
+	} else {
 		return jsx("svg", {
 			ref,
 			viewBox,
@@ -19,5 +51,5 @@ export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml)
 			...props,
 			dangerouslySetInnerHTML: { __html: xml },
 		});
-	});
+	}
 };

--- a/runtime/react.js
+++ b/runtime/react.js
@@ -1,15 +1,48 @@
-import { createElement, forwardRef } from "react";
+import { createElement, forwardRef, version } from "react";
 
-export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => {
+export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (
+	viewBox,
+	width,
+	height,
+	symbol
+) => {
 	let node = createElement("use", { href: symbol });
 
-	return forwardRef((props, ref) => {
-		return createElement("svg", { ref, viewBox, width, height, ...props }, node);
-	});
+	if (version.split(".")[0] < "19") {
+		return forwardRef((props, ref) => {
+			return createElement(
+				"svg",
+				{ ref, viewBox, width, height, ...props },
+				node
+			);
+		});
+	} else {
+		return createElement(
+			"svg",
+			{ ref, viewBox, width, height, ...props },
+			node
+		);
+	}
 };
 
-export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => {
-	return forwardRef((props, ref) => {
+export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (
+	viewBox,
+	width,
+	height,
+	xml
+) => {
+	if (version.split(".")[0] < "19") {
+		return forwardRef((props, ref) => {
+			return createElement("svg", {
+				ref,
+				viewBox,
+				width,
+				height,
+				...props,
+				dangerouslySetInnerHTML: { __html: xml },
+			});
+		});
+	} else {
 		return createElement("svg", {
 			ref,
 			viewBox,
@@ -18,5 +51,5 @@ export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml)
 			...props,
 			dangerouslySetInnerHTML: { __html: xml },
 		});
-	});
+	}
 };


### PR DESCRIPTION
I upgraded my project to React 19 and started getting errors from the svg components generated by magical-svg. React 19 no longer needs forwardRef and removing it from the runtime fixes the errors I was seeing.