### PR TITLE
feat: mark Vue components as raw

### DIFF
--- a/runtime/vue.js
+++ b/runtime/vue.js
@@ -1,4 +1,4 @@
-import { createElementBlock, createElementVNode, openBlock } from "vue";
+import { createElementBlock, createElementVNode, markRaw, openBlock } from "vue";
 
 export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => {
 	// <svg viewBox="{{viewBox}}" width="{{width}}" height="{{height}}"><use href="{{symbol}}" /></svg>
@@ -6,20 +6,20 @@ export var createSvg = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol)
 	let _hoisted_2 = createElementVNode("use", { href: symbol }, null, -1);
 	let _hoisted_3 = [_hoisted_2];
 
-	return {
+	return markRaw({
 		render: (_ctx, _cache) => {
 			return openBlock(), createElementBlock("svg", _hoisted_1, _hoisted_3);
 		},
-	};
+	});
 };
 
 export var createSvgDEV = /*@__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => {
 	// <svg viewBox="{{viewBox}}" width="{{width}}" height="{{height}}" innerHTML="{{xml}}"></svg>
 	let _hoisted_1 = { viewBox, width, height, innerHTML: xml };
 
-	return {
+	return markRaw({
 		render: (_ctx, _cache) => {
 			return openBlock(), createElementBlock("svg", _hoisted_1);
 		},
-	};
+	});
 };


### PR DESCRIPTION
prevents complaints from icons being passed around through deep refs