### PR TITLE
Return a function from DOM runtime

### DIFF
--- a/runtime/dom.js
+++ b/runtime/dom.js
@@ -1,7 +1,7 @@
 // A solid-like use of <template> would be shorter, but this is done the "old" way to avoid relying on innerHTML
 // in production so that it can be used in places where there have strict policies about that (such as AMO)
 
-export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => {
+export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => () => {
 	let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 	let use = document.createElementNS("http://www.w3.org/2000/svg", "use");
 	viewBox && svg.setAttribute("viewBox", viewBox);
@@ -12,7 +12,7 @@ export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol)
 	return svg;
 };
 
-export var createSvgDEV = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => {
+export var createSvgDEV = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => () => {
 	let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 	viewBox && svg.setAttribute("viewBox", viewBox);
 	width && svg.setAttribute("width", width);


### PR DESCRIPTION
When using the DOM runtime it was creating the svg once in module scope, meaning it could only ever be inserted into a page once.

eg
```js
// This default export is the actual SVGElement
import viteLogo from "./assets/vite.svg";

document.querySelector("#app").append(viteLogo);
document.querySelector("#app").append("<p> Hello Vite</p>");
document.querySelector("#app").append(viteLogo); // when this is appended the first one is removed by the browser
```

This updates the generated DOM runtime code to match the description in the readme which says 
> dom (default): exports a function you can call (takes no arguments) and returns a DOM element.

```js
// This default export is now a function
import viteLogo from "./assets/vite.svg";

document.querySelector("#app").append(viteLogo());
document.querySelector("#app").append("<p> Hello Vite</p>");
document.querySelector("#app").append(viteLogo());
```
Resulting in two vite logos rendered.

This changes the existing API so would be a breaking change.