### PR TITLE
Adds Ember as a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ export default defineConfig({
 - `vue`: exports a Vue component (as if it was a `.vue` file)
 - `vue-vapor`: exports a Vue Vapor[^vapor] component (as if it was a `.vue` file)
 - `solid`: exports a Solid component
+- `ember`: exports an Ember component
 
 [^vapor]: Vue's high-performance subset introduced in Vue 3.6
 

--- a/runtime/ember.js
+++ b/runtime/ember.js
@@ -1,0 +1,23 @@
+import { template } from "@ember/template-compiler";
+
+export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, symbol) => {
+  return template(`<svg viewBox={{viewBox}} width={{width}} height={{height}} ...attributes><use href={{symbol}} /></svg>`, {
+    scope: () => ({
+      viewBox,
+      width,
+      height,
+      symbol
+    })
+  });
+};
+
+export var createSvgDEV = /*#__NO_SIDE_EFFECTS__*/ (viewBox, width, height, xml) => {
+  return template(`<svg viewBox={{viewBox}} width={{width}} height={{height}} ...attributes>{{{xml}}}</svg>`, {
+    scope: () => ({
+      viewBox,
+      width,
+      height,
+      xml
+    })
+  });
+};


### PR DESCRIPTION
Allows an ember dev to work with SVGs as actual ember component.

```glimmer-js
import MySvg from "my-svg.svg";

<template>
  <MySvg class="adding-a-class" />
</template>
```