### PR TITLE
Add custom SVGO configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ optimization entirely by setting `svgo` to `false`, or pass a custom SVGO config
 
 When a config object is provided, it is **deep-merged** with the plugin's default config:
 - Top-level options (`multipass`, `floatPrecision`, `js2svg`, `datauri`) override defaults.
-- Plugins are merged by name: if you provide a plugin with the same name as a default one, your version replaces it.
-  New plugins are appended after the defaults.
-- `preset-default` is special-cased: its `overrides` are merged so you can selectively override individual plugin
+- New plugins are always added after the defaults.
+- Configuring a plugin that is already included in the defaults, it is always replaced without merging the configurations, but kept in the original order.
+- `preset-default` is a special case: its `params` and `overrides` are shallowly merged so you can selectively override individual plugin
   settings without losing the other defaults.
 
 The plugin's default SVGO config is:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ export default defineConfig({
 			// You can also change the output to react (or any supported target) to get a component you can use.
 			target: 'preact',
 
-			// By default, the svgs are optimized with svgo. You can disable this by setting this to false.
+			// By default, the svgs are optimized with svgo. You can disable this by setting this to false or you 
+			// can provide your own SVGO config object to customize the behavior. See the SVGO configuration
+			// section below for more details.
 			svgo: false,
 
 			// By default, width and height set on SVGs are not preserved.
@@ -86,6 +88,9 @@ export default defineConfig({
 #### SVGO configuration
 By default, SVGs are optimized with [SVGO](https://github.com/svg/svgo) during production builds. You can disable
 optimization entirely by setting `svgo` to `false`, or pass a custom SVGO config object to customize the behavior.
+
+> [!NOTE]  
+> There are SVGO configurations that can break sprites. Ensure your custom configuration builds your production sprites correctly.
 
 When a config object is provided, it is **deep-merged** with the plugin's default config:
 - Top-level options (`multipass`, `floatPrecision`, `js2svg`, `datauri`) override defaults.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,69 @@ export default defineConfig({
 })
 ```
 
+#### SVGO configuration
+By default, SVGs are optimized with [SVGO](https://github.com/svg/svgo) during production builds. You can disable
+optimization entirely by setting `svgo` to `false`, or pass a custom SVGO config object to customize the behavior.
+
+When a config object is provided, it is **deep-merged** with the plugin's default config:
+- Top-level options (`multipass`, `floatPrecision`, `js2svg`, `datauri`) override defaults.
+- Plugins are merged by name: if you provide a plugin with the same name as a default one, your version replaces it.
+  New plugins are appended after the defaults.
+- `preset-default` is special-cased: its `overrides` are merged so you can selectively override individual plugin
+  settings without losing the other defaults.
+
+The plugin's default SVGO config is:
+```js
+{
+	plugins: [
+		{
+			name: 'preset-default',
+			params: {
+				overrides: {
+					cleanupNumericValues: false,
+					removeHiddenElems: false,
+					removeUselessDefs: false, // for file assets; default for sprites
+					cleanupIds: { minify: false, remove: false },
+					convertPathData: false,
+				},
+			},
+		},
+		'removeTitle',
+		'inlineStyles',
+	],
+}
+```
+
+Example: enable multipass and re-enable `convertPathData` with custom params:
+```js
+magicalSvg({
+	svgo: {
+		multipass: true,
+		plugins: [
+			{
+				name: 'preset-default',
+				params: {
+					overrides: {
+						convertPathData: { floatPrecision: 3 },
+					},
+				},
+			},
+		],
+	},
+})
+```
+
+Example: add a plugin that isn't in the defaults:
+```js
+magicalSvg({
+	svgo: {
+		plugins: [
+			'removeDimensions',
+		],
+	},
+})
+```
+
 #### Targets
 - `dom` (default): exports a function you can call (takes no arguments) and returns a DOM element.
 - `react19`: exports a functional React component (classic runtime)

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@
 
 import type { Plugin, FilterPattern } from 'vite'
 import type { PluginContext, OutputOptions } from 'rollup'
-import type { Config } from 'svgo'
+import type { Config, PluginConfig } from 'svgo'
 
 import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
@@ -49,7 +49,7 @@ export type MagicalSvgConfig = {
 	exclude?: FilterPattern | undefined
 	target?: SupportedTarget,
 	symbolId?: SymbolIdGenerator,
-	svgo?: boolean,
+	svgo?: boolean | Config,
 
 	preserveWidthHeight?: boolean
 	setWidthHeight?: { width: string, height: string }
@@ -156,6 +156,68 @@ async function load (ctx: PluginContext, file: string, serve: boolean, symbolIdG
 	xml.svg.$.id = symbolIdGen?.(file, raw) || generateId(raw);
 
 	return [ raw, xml, imports ]
+}
+
+function getPluginName (plugin: PluginConfig): string {
+	return typeof plugin === 'string' ? plugin : plugin.name
+}
+
+function mergeSvgoConfigs (defaults: Config, overrides: Config): Config {
+	const merged: Config = { ...defaults }
+
+	// Shallow-merge top-level options
+	if (overrides.path !== undefined) merged.path = overrides.path
+	if (overrides.multipass !== undefined) merged.multipass = overrides.multipass
+	if (overrides.floatPrecision !== undefined) merged.floatPrecision = overrides.floatPrecision
+	if (overrides.js2svg !== undefined) merged.js2svg = { ...defaults.js2svg, ...overrides.js2svg }
+	if (overrides.datauri !== undefined) merged.datauri = overrides.datauri
+
+	// Merge plugins by name
+	if (overrides.plugins) {
+		const defaultPlugins = [...(defaults.plugins ?? [])]
+		const result: PluginConfig[] = []
+
+		for (const defaultPlugin of defaultPlugins) {
+			const defaultName = getPluginName(defaultPlugin)
+			const override = overrides.plugins.find((p) => getPluginName(p) === defaultName)
+
+			if (!override) {
+				// No override for this default plugin, keep as-is
+				result.push(defaultPlugin)
+			} else if (defaultName === 'preset-default' && typeof defaultPlugin !== 'string' && typeof override !== 'string') {
+				// Deep-merge preset-default overrides
+				const defaultParams = (defaultPlugin as any).params ?? {}
+				const overrideParams = (override as any).params ?? {}
+
+				result.push({
+					name: 'preset-default',
+					params: {
+						...defaultParams,
+						...overrideParams,
+						overrides: {
+							...defaultParams.overrides,
+							...overrideParams.overrides,
+						},
+					},
+				})
+			} else {
+				// Replace default plugin with user's version
+				result.push(override)
+			}
+		}
+
+		// Append any user plugins that don't exist in defaults
+		for (const userPlugin of overrides.plugins) {
+			const userName = getPluginName(userPlugin)
+			if (!defaultPlugins.some((p) => getPluginName(p) === userName)) {
+				result.push(userPlugin)
+			}
+		}
+
+		merged.plugins = result
+	}
+
+	return merged
 }
 
 function generateFilename (template: AssetName, file: string, raw: string) {
@@ -458,7 +520,7 @@ export function magicalSvgPlugin (config: MagicalSvgConfig = {}): Plugin {
 				const builder = new Builder()
 				let xml = builder.buildObject(asset.xml)
 				if (config.svgo !== false) {
-					const opts: Config = {
+					const defaultOpts: Config = {
 						plugins: [
 							{
 								name: 'preset-default',
@@ -476,8 +538,13 @@ export function magicalSvgPlugin (config: MagicalSvgConfig = {}): Plugin {
 								},
 							},
 							'removeTitle',
+							'inlineStyles'
 						],
 					}
+
+					const opts = typeof config.svgo === 'object'
+						? mergeSvgoConfigs(defaultOpts, config.svgo)
+						: defaultOpts
 
 					try {
 						const res = svgoOptimize(xml, opts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,8 +534,7 @@ export function magicalSvgPlugin (config: MagicalSvgConfig = {}): Plugin {
 									},
 								},
 							},
-							'removeTitle',
-							'inlineStyles'
+							'removeTitle'
 						],
 					}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ function mergeSvgoConfigs (defaults: Config, overrides: Config): Config {
 
 	// Merge plugins by name
 	if (overrides.plugins) {
-		const defaultPlugins = [...(defaults.plugins ?? [])]
+		const defaultPlugins = defaults.plugins ?? [];
 		const result: PluginConfig[] = []
 
 		for (const defaultPlugin of defaultPlugins) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,10 +181,7 @@ function mergeSvgoConfigs (defaults: Config, overrides: Config): Config {
 			const defaultName = getPluginName(defaultPlugin)
 			const override = overrides.plugins.find((p) => getPluginName(p) === defaultName)
 
-			if (!override) {
-				// No override for this default plugin, keep as-is
-				result.push(defaultPlugin)
-			} else if (defaultName === 'preset-default' && typeof defaultPlugin !== 'string' && typeof override !== 'string') {
+			if (override && defaultName === 'preset-default' && typeof defaultPlugin !== 'string' && typeof override !== 'string') {
 				// Deep-merge preset-default overrides
 				const defaultParams = (defaultPlugin as any).params ?? {}
 				const overrideParams = (override as any).params ?? {}
@@ -202,7 +199,7 @@ function mergeSvgoConfigs (defaults: Config, overrides: Config): Config {
 				})
 			} else {
 				// Replace default plugin with user's version
-				result.push(override)
+				result.push(override ?? defaultPlugin)
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,8 +183,8 @@ function mergeSvgoConfigs (defaults: Config, overrides: Config): Config {
 
 			if (override && defaultName === 'preset-default' && typeof defaultPlugin !== 'string' && typeof override !== 'string') {
 				// Deep-merge preset-default overrides
-				const defaultParams = (defaultPlugin as any).params ?? {}
-				const overrideParams = (override as any).params ?? {}
+				const defaultParams = defaultPlugin.params ?? {}
+				const overrideParams = override.params ?? {}
 
 				result.push({
 					name: 'preset-default',


### PR DESCRIPTION
This lets a user supply a custom svgo config that is merged with the defaults, option still accepts a boolean to turn on or off.

~~I also added `inlineStyle` as a default plugin so the css variable strategy of updating colours from site css works in production builds without needing to manually inline all the css onto the elements.~~