### PR TITLE
Add two new targets ("raw" and "svelte")

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export default defineConfig({
 - `vue-vapor`: exports a Vue Vapor[^vapor] component (as if it was a `.vue` file)
 - `solid`: exports a Solid component
 - `ember`: exports an Ember component
+- `raw`: exports an instance of the [`RawSvg`](src/index.ts#L79) interface, including a string to set as the `.innerHTML` of an existing `<svg>` element
 
 [^vapor]: Vue's high-performance subset introduced in Vue 3.6.
 [^oopsie-dom]: This target was supposed to behave as `dom-fn` actually, but I messed up the implementation. To avoid

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ export default defineConfig({
 - `solid`: exports a Solid component
 - `ember`: exports an Ember component
 - `raw`: exports an instance of the [`RawSvg`](src/index.ts#L79) interface, including a string to set as the `.innerHTML` of an existing `<svg>` element
+- `svelte`: exports a Svelte snippet (to be used with `{@render }`)
 
 [^vapor]: Vue's high-performance subset introduced in Vue 3.6.
 [^oopsie-dom]: This target was supposed to behave as `dom-fn` actually, but I messed up the implementation. To avoid

--- a/runtime/raw.js
+++ b/runtime/raw.js
@@ -1,0 +1,3 @@
+export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (symbol, width, height) => ({ raw: `<use href=${symbol}>`, width, height })
+
+export var createSvgDEV = /*#__NO_SIDE_EFFECTS__*/ (xml, width, height) => ({ raw: xml, width, height })

--- a/runtime/svelte.js
+++ b/runtime/svelte.js
@@ -1,0 +1,7 @@
+import { createRawSnippet } from "svelte";
+
+const template = /*#__NO_SIDE_EFFECTS__*/ (svg) => createRawSnippet(() => ({ render: () => svg }));
+
+export var createSvg = /*#__NO_SIDE_EFFECTS__*/ (symbol, width, height) => template(`<svg width=${width} height=${height}><use href=${symbol}>`);
+
+export var createSvgDEV = /*#__NO_SIDE_EFFECTS__*/ (xml, width, height) => template(`<svg width=${width} height=${height}>${xml}`);

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -52,6 +52,7 @@ export type SupportedTarget =
 	| 'solid'
 	| 'ember'
 	| 'raw'
+	| 'svelte'
 
 /** @internal */
 export function generateDev (target: SupportedTarget, width: XmlValue, height: XmlValue, xml: any): string {

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -51,6 +51,7 @@ export type SupportedTarget =
 	| 'vue-vapor'
 	| 'solid'
 	| 'ember'
+	| 'raw'
 
 /** @internal */
 export function generateDev (target: SupportedTarget, width: XmlValue, height: XmlValue, xml: any): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,12 @@ export type MagicalSvgConfig = {
 	restoreMissingViewBox?: boolean
 }
 
+export interface RawSvg {
+	raw: string;
+	width: string;
+	height: string;
+}
+
 let ROOT = '/'
 const ASSET_RE = /__MAGICAL_SVG_SPRITE__(_[0-9a-f]{8})__/g
 

--- a/test/__snapshots__/codegen.test.ts.snap
+++ b/test/__snapshots__/codegen.test.ts.snap
@@ -713,6 +713,65 @@ exports[`solid target > generates prod-inline code with symbol reference 1`] = `
 	"
 `;
 
+exports[`svelte target > generateProdSpriteCode > generates prod-sprite code with placeholder 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___abc12345__, 24, 24);
+	"
+`;
+
+exports[`svelte target > generateProdSpriteCode > includes preamble imports 1`] = `
+"import "/path/to/dep.svg";
+
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___def67890__, 16, 16);
+	"
+`;
+
+exports[`svelte target > generateProdSpriteCode > passes viewBox, width, and height to codegen 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___test1234__, 48, 48);
+	"
+`;
+
+exports[`svelte target > generates dev code 1`] = `
+"
+
+		import { createSvgDEV } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvgDEV("<symbol xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" id=\\"_c44c3d0e\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"#ff0000\\" stroke=\\"#000000\\"/></symbol><use href='#_c44c3d0e'/>", 24, 24);
+	"
+`;
+
+exports[`svelte target > generates dev-inline code with inlineSymbol 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvg('#_63a603ad', 24, 24);
+	
+
+		;(() => {
+			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+			svg.setAttribute('height', '0')
+			svg.setAttribute('width', '0')
+			svg.innerHTML = "<symbol xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" id=\\"_63a603ad\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"#ff0000\\" stroke=\\"#000000\\"/></symbol>"
+			document.body.prepend(svg)
+		})();
+	"
+`;
+
+exports[`svelte target > generates prod-inline code with symbol reference 1`] = `
+"import "./dep.svg";
+
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/svelte.js';
+		export default /*#__PURE__*/ createSvg('#_abc12345', 24, 24);
+	"
+`;
+
 exports[`vue target > generateProdSpriteCode > generates prod-sprite code with placeholder 1`] = `
 "
 

--- a/test/__snapshots__/codegen.test.ts.snap
+++ b/test/__snapshots__/codegen.test.ts.snap
@@ -359,6 +359,65 @@ exports[`preact-jsx target > generates prod-inline code with symbol reference 1`
 	"
 `;
 
+exports[`raw target > generateProdSpriteCode > generates prod-sprite code with placeholder 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___abc12345__, 24, 24);
+	"
+`;
+
+exports[`raw target > generateProdSpriteCode > includes preamble imports 1`] = `
+"import "/path/to/dep.svg";
+
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___def67890__, 16, 16);
+	"
+`;
+
+exports[`raw target > generateProdSpriteCode > passes viewBox, width, and height to codegen 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvg(__MAGICAL_SVG_SPRITE___test1234__, 48, 48);
+	"
+`;
+
+exports[`raw target > generates dev code 1`] = `
+"
+
+		import { createSvgDEV } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvgDEV("<symbol xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" id=\\"_c44c3d0e\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"#ff0000\\" stroke=\\"#000000\\"/></symbol><use href='#_c44c3d0e'/>", 24, 24);
+	"
+`;
+
+exports[`raw target > generates dev-inline code with inlineSymbol 1`] = `
+"
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvg('#_63a603ad', 24, 24);
+	
+
+		;(() => {
+			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+			svg.setAttribute('height', '0')
+			svg.setAttribute('width', '0')
+			svg.innerHTML = "<symbol xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" id=\\"_63a603ad\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"#ff0000\\" stroke=\\"#000000\\"/></symbol>"
+			document.body.prepend(svg)
+		})();
+	"
+`;
+
+exports[`raw target > generates prod-inline code with symbol reference 1`] = `
+"import "./dep.svg";
+
+
+		import { createSvg } from 'vite-plugin-magical-svg/runtime/raw.js';
+		export default /*#__PURE__*/ createSvg('#_abc12345', 24, 24);
+	"
+`;
+
 exports[`react target > generateProdSpriteCode > generates prod-sprite code with placeholder 1`] = `
 "
 

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -67,6 +67,7 @@ describe.each([
 	'solid',
 	'ember',
 	'raw',
+	'svelte',
 ] as const)('%s target', (target) => {
 	it('generates dev code', async () => {
 		const raw = await readFile(fixture('simple.svg'), 'utf8')

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -66,6 +66,7 @@ describe.each([
 	'vue-vapor',
 	'solid',
 	'ember',
+	'raw',
 ] as const)('%s target', (target) => {
 	it('generates dev code', async () => {
 		const raw = await readFile(fixture('simple.svg'), 'utf8')


### PR DESCRIPTION
This is a hopefully non-broken port of [my local patches](https://git.gay/kopper/outpost-fe-2/commits/branch/main/patches/vite-plugin-magical-svg.patch).

The raw target is intended for cases where you want to control the surrounding `<svg>` element to e.g. add classes (in my case: i have an `<Icon/>` component which takes in classes and a size override). This is the current version I use and if the port didn't break it seems to work in both dev and when built as a SPA.

The svelte target was what I used before switching to raw, it creates a snippet (which seems to be the only documented way to create anything component adjacent in plain JS) of the entire svg. I know it works in a dev environment but not entirely sure if it would break once built. I can't see why it would, but I didn't test it.

The patches don't seem that difficult to maintain locally so if this doesn't get merged it's not a big deal to me. I just wanted to submit upstream in case they're useful.